### PR TITLE
Make pair_with zsh compatible

### DIFF
--- a/pair_with.sh
+++ b/pair_with.sh
@@ -1,36 +1,20 @@
-#! /bin/bash
+# These functions set and unset environment variables
+# As such, they need to be compatible with bash and zsh
+# so they can run in the current context, and not as a child process
 
 function pair_with()
 {
-  local username=$1
-  local profile=`curl -H "Accept: application/json" -s GET "https://api.github.com/users/$username"`
-  local name=`echo $profile | jq -r ".name"`
-  local email=`echo $profile | jq -r ".email"`
-  if [ "$name" == "null" ]; then
-    local profilemessage=`echo $profile | jq -r ".message"`
-    if [ "$profilemessage" == "Not Found" ]; then
-      echo "$username is not a valid github username"
-      return 1
-    fi
-
-    if [[ "$profilemessage" = *"API rate limit exceeded"* ]]; then
-      echo "The Github API is currently rate limited"
-      echo "Please manually export GIT_PAIR_NAME and GIT_PAIR_EMAIL"
-      return 2
+  if [ "$#" -eq 0 ]; then
+    work_solo
+  else
+    local output=`pair_with_impl.sh $1`
+    if [ "$?" -eq 0 ]; then
+      export GIT_PAIR_USERNAME=`echo "${output}" | head -1 | tail -1`
+      export GIT_PAIR_NAME=`echo "${output}" | head -2 | tail -1`
+      export GIT_PAIR_EMAIL=`echo "${output}" | head -3 | tail -1`
+      echo "Now pairing with $GIT_PAIR_NAME <$GIT_PAIR_EMAIL>"
     fi
   fi
-
-  if [ "$email" == "null" ]; then
-    local events=`curl -H "Accept: application/json" -s GET "https://api.github.com/users/$username/events/public"`
-    email=$(echo $events | jq -r ".[].payload?.commits?[]?.author? | select(.name == \"$name\") | .email" | head -n 1)
-    if [ -z "$EMAIL" ]; then
-      email="$1@users.noreply.github.com"
-    fi
-  fi
-  export GIT_PAIR_USERNAME=$username
-  export GIT_PAIR_NAME=$name
-  export GIT_PAIR_EMAIL=$email
-  echo "Now pairing with $GIT_PAIR_NAME <$GIT_PAIR_EMAIL>"
 }
 
 function work_solo()

--- a/pair_with_impl.sh
+++ b/pair_with_impl.sh
@@ -1,0 +1,35 @@
+#! /bin/bash
+
+function pair_with()
+{
+  local username=$1
+  local profile=`curl -H "Accept: application/json" -s GET "https://api.github.com/users/$username"`
+  local name=`echo $profile | jq -r ".name"`
+  local email=`echo $profile | jq -r ".email"`
+  if [ "$name" == "null" ]; then
+    local profilemessage=`echo $profile | jq -r ".message"`
+    if [ "$profilemessage" == "Not Found" ]; then
+      echo "$username is not a valid github username"
+      return 1
+    fi
+
+    if [[ "$profilemessage" = *"API rate limit exceeded"* ]]; then
+      echo "The Github API is currently rate limited"
+      echo "Please manually export GIT_PAIR_NAME and GIT_PAIR_EMAIL"
+      return 2
+    fi
+  fi
+
+  if [ "$email" == "null" ]; then
+    local events=`curl -H "Accept: application/json" -s GET "https://api.github.com/users/$username/events/public"`
+    email=$(echo $events | jq -r ".[].payload?.commits?[]?.author? | select(.name == \"$name\") | .email" | head -n 1)
+    if [ -z "$EMAIL" ]; then
+      email="$1@users.noreply.github.com"
+    fi
+  fi
+  echo $username
+  echo $name
+  echo $email
+}
+
+pair_with $1

--- a/setup.sh
+++ b/setup.sh
@@ -13,13 +13,12 @@ function _require()
 function _addToStartup()
 {
   local path=$1
-  local dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
   if [ -f $path ]; then
     if grep -q 'pair_with.sh' "$path"; then
       echo "pair_with_sh is already added to $path"
     else
       echo "Adding the pair_with script to $path"
-      echo "[ -f $dir/pair_with.sh ] && . $dir/pair_with.sh" >> $path
+      echo "[ -f /usr/local/bin/pair_with.sh ] && . /usr/local/bin/pair_with.sh" >> $path
     fi
   fi
 }
@@ -46,8 +45,12 @@ function setup()
     exit 1
   fi
 
-  # Copy the commit-msg to the hooks path
   local dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+  # Move the scripts to /usr/local/bin
+  cp $dir/pair_with.sh /usr/local/bin
+  cp $dir/pair_with_impl.sh /usr/local/bin
+
+  # Copy the commit-msg to the hooks path
   cp $dir/commit-msg $hookpath
 
   _addToStartup "${HOME}/.bashrc"


### PR DESCRIPTION
Move the implementation to pair_with_impl so it can be run soley in bash.

pair_with.sh now contains just the environment setting part, so it can be sourced

In order to run pair_with_impl from pair_with, I needed to move everything to a known location as $0 inside of pair_with was just -bash instead of the directory